### PR TITLE
Fix travis failed builds with nix

### DIFF
--- a/rola.nix
+++ b/rola.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, base, containers, hspec, megaparsec_7_0_4, stdenv }:
+{ mkDerivation, base, containers, hspec, megaparsec, stdenv }:
 mkDerivation {
   pname = "rola";
   version = "0.1.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
-  libraryHaskellDepends = [ base containers megaparsec_7_0_4 ];
+  libraryHaskellDepends = [ base containers megaparsec ];
   executableHaskellDepends = [ base ];
-  testHaskellDepends = [ base containers hspec megaparsec_7_0_4 ];
+  testHaskellDepends = [ base containers hspec megaparsec ];
   doHaddock = false;
   homepage = "https://github.com/appositum/rola#readme";
   license = stdenv.lib.licenses.asl20;

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc844", doBenchmark ? false }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
 
 let
   inherit (nixpkgs) pkgs;


### PR DESCRIPTION
`nix-build` failed on [travis](https://travis-ci.com/appositum/rola/builds/99864836) with this message:
```
error: anonymous function at /home/travis/build/appositum/rola/rola.nix:1:1 called without required argument 'megaparsec_7_0_4', at /nix/store/7v01szrjw921m8zzqlzf6a95j5ibm7p6-nixpkgs-19.03pre167327.11cf7d6e1ff/nixpkgs/pkgs/development/haskell-modules/make-package-set.nix:87:27
```

The project needs Megaparsec 7, which was only available through nix with the package `megaparsec_7_0_4`. The package doesn't exist anymore and the 7th version was bumped to the `megaparsec` package, generating the build error.

Fixed it by using default versions for GHC and Megaparsec.